### PR TITLE
Added Navbar closing when clicked outside it

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState,useEffect, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
 import Logo from "../../assets/image/slide.png";
 import NavLink from "./NavLink";
@@ -10,6 +10,24 @@ const Navbar = () => {
   const [open, setOpen] = useState(false);
   const { user } = useUserAuth();
   const location = useLocation();
+  const navbarRef = useRef(null);
+
+  useEffect(() => {
+    // Function to handle clicks outside of the navbar
+    const handleOutsideClick = (event) => {
+      if (navbarRef.current && !navbarRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+
+    // Attach the event listener when the component mounts
+    document.addEventListener("click", handleOutsideClick);
+
+    // Clean up the event listener when the component unmounts
+    return () => {
+      document.removeEventListener("click", handleOutsideClick);
+    };
+  }, []);
 
   return (
     <nav
@@ -17,13 +35,14 @@ const Navbar = () => {
       style={{ position: "sticky", top: 0, zIndex: 20 }}
     >
       <div
+        ref={navbarRef}
         className={`${styles.boxWidth} flex md:flex-row flex-col items-center font-normal justify-between`}
       >
         <div className="z-50 px-4 py-2 md:w-auto w-full flex justify-between">
           <img
             src={Logo}
             alt="logo"
-            className="md:cursor-pointer h-12 my-auto" loading='lazy'
+            className="md:cursor-pointer h-12 my-auto"
           />
           <div className="md:hidden py-5 flex justify-center ml-auto mr-4 items-center self-end gap-x-4">
             {user ? (


### PR DESCRIPTION
## Related Issue

Navbar remained open when the users click outside the Navbar on their mobile screens.
<!--
Provide information about the issue or bug that is being addressed.
-->

Closes: #126 


## Description of Changes
- Added Navbar closing functionality when user click outside the Navbar for Mobile Screens.
<!-- 
Clearly and concisely describe the modifications made to successfully resolve the assigned issue. Include any pertinent information about new files or any other relevant details.

For example:
- Added a new function to handle XYZ.
- Updated the ABC module to fix the bug.
- Refactored code in the DEF class for improved performance.
-->

## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [ ] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Video
### Result
[navbar closing clicked outside.webm](https://github.com/sourabhsikarwar/Scene-Movie-Platform/assets/66116440/2a5d10a8-a69e-46bb-83a6-d8eada23b56a) 

