### PR TITLE
fix: improperly visible go to top button on footer ⚒️

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -37,7 +37,7 @@ const ScrollToTop = () => {
             <button
       type="button"
       className={`  fixed p-2 bg-gradient-to-r from-[#00264D] to-[#1357BD] bg-opacity-100 shadow-lg rounded-full z-20 ${
-        isVisible ? isBottom?'bottom-20 right-4' :' bottom-4 right-4' : 'hidden'
+        isVisible ? isBottom?'bottom-32 right-16' :'hidden' : 'hidden'
       } hover:from-indigo-500
       hover:via-purple-700
       hover:bg-gradient-to-r`}


### PR DESCRIPTION
## Related Issue

Closes: #499 

## Description of Changes
- The go to top button has not properly placed, so that the button is not visible. Because the Alan Chat bot takes the space.
- This PR we make changes to the Go to top button in it's position to move up a little bit.

## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [x] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Screenshots

|      Original       |       Updated        |
| :-----------------: | :------------------: |
| ![](https://user-images.githubusercontent.com/92252895/257032971-ce6cb1af-6e9c-4d83-932e-11d6342cc3ca.png)| ![image](https://github.com/sourabhsikarwar/Scene-Movie-Platform/assets/92252895/ecd10964-66a6-4523-b14c-616bcda64a82)  |



Please provide any necessary screenshots to illustrate the changes made.
