### PR TITLE
fixes #620 issue contact number input field is overflowing from box i…

### DIFF
--- a/src/components/Signup.jsx
+++ b/src/components/Signup.jsx
@@ -191,9 +191,9 @@ const Signup = () => {
               onKeyDown={handleKeyDown}
               countryCodeEditable={false}
               inputClass="focus:ring-0"
-              inputStyle={{ border: "0px"}}
+              inputStyle={{ border: "0px",width:"100%"}}
               containerClass="border-none outline-none focus:ring-0"
-              className={`w-full bg-white rounded border ${
+              className={`bg-white rounded border ${
                 errors.phoneNumberError ? "border-red-500" : "border-gray-300"
               } focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 text-base outline-none py-1 text-gray-700 leading-8 transition-colors duration-200 ease-in-out`}
               aria-labelledby="phone number"


### PR DESCRIPTION
## Related Issue
In singup page the contact number input field is overflowing in small devices 

Closes: #620 

## Description of Changes

you are using a npm package called react-phone-input-2
so this package's default styling is width:300px; that's why your tailwindcss style w-full not applies so i made a small changes in your PhoneInput component there is props called inputStyle props so in this props we can pass width:"100%" to solve the bug.

For example:
changes in singup.jsx file in PhoneInput component in inputstyle props pass a width : "100%" to fix this issue

## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
-My code follows the style guidelines of this project. yes i have checked the guidelines of this project
-->

## Screenshots

|      Original       |       Updated        |
| :-----------------: | :------------------: |
![ll](https://github.com/sourabhsikarwar/Scene-Movie-Platform/assets/82786865/b2232e33-dc96-461c-9c4f-ced184ef0845)

![asdf](https://github.com/sourabhsikarwar/Scene-Movie-Platform/assets/82786865/939c6ee4-bde2-490d-bfd6-ef2abf2784d7)

